### PR TITLE
removing rich text editor from mobile touch plugin

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -109,4 +109,20 @@ class DocumentsController < ApplicationController
       i unless cannot? :read, i
     end
   end
+
+    before_filter :prepare_for_mobile
+
+  def mobile_device?
+    if session[:mobile_param]
+      session[:mobile_param] == "1"
+    else
+      request.env["HTTP_USER_AGENT"] =~ /Mobile|webOS/
+    end
+  end
+  helper_method :mobile_device?
+
+  def prepare_for_mobile
+    session[:mobile_param] = params[:mobile] if params[:mobile]
+   # request.format = :mobile if mobile_device?
+  end
 end

--- a/app/views/documents/_annotator-setup.html.erb
+++ b/app/views/documents/_annotator-setup.html.erb
@@ -82,16 +82,20 @@ jQuery(function ($) {
   });
 
   var optionsRichText = {
-    editor_enabled: <%= ENV["ANNOTATOR_RICHTEXT"] %>,
+    editor_enabled: '<%= ENV["ANNOTATOR_RICHTEXT"] %>',
     tinymce: {
       'toolbar': '<%= ENV["ANNOTATOR_RICHTEXT_CONFIG"] %>'
     }
   };
 
-  studio.annotator('addPlugin', 'RichText', optionsRichText);
   studio.annotator("addPlugin", "Touch");
   var subscriber = $('#textcontent').annotator().data('annotator');
   $('.annotator-item').addClass('hide');
+
+  <% if !mobile_device? %>
+    studio.annotator('addPlugin', 'RichText', optionsRichText);
+  <% end %>
+
 
   // these three click and tap handlers manage the rich text editor show and hide on mobile and desktop
   $('.annotator-button').on('tap', function(){

--- a/config/application.sample.yml
+++ b/config/application.sample.yml
@@ -1,8 +1,4 @@
 development:
-    ANNOTATOR_FILTER:                      false
-    ANNOTATOR_RICHTEXT:                    true
-    ANNOTATOR_RICHTEXT_CONFIG:             undo redo | styleselect | bold italic | link image media | code
-    RUNTIMEERROR_EMAIL:                    example@example.com
     GOOGLE_VERIFICATION_CODE:
     DEFAULT_USER_GROUP: public
     GOOGLE_ANALYTICS_CODE:
@@ -19,6 +15,15 @@ development:
     API_SECRET:
     API_CONSUMER: localhost
     CONFIRMATION_GRACE_PERIOD: 2
+    RUNTIMEERROR_EMAIL:                    example@example.com
+    ANNOTATOR_FILTER:                      false
+    ANNOTATOR_RICHTEXT:                    true
+    ANNOTATOR_RICHTEXT_CONFIG:             undo redo | styleselect | bold italic | link image media | code
+    AWS_ACCESS_KEY_ID:
+    AWS_SECRET_ACCESS_KEY:
+    AWS_BIN_NAME: # Bucket name
+    AWS_REGION:
+    DEVISE_SECRET_KEY:                    blah-blah # use: `rails g secret` to generate a value
 
 production:
     DEFAULT_NEW_USER_GROUP: public
@@ -44,3 +49,8 @@ production:
     ANNOTATOR_FILTER:                      false
     ANNOTATOR_RICHTEXT:                    true
     ANNOTATOR_RICHTEXT_CONFIG:             undo redo | styleselect | bold italic | link image media | code
+    AWS_ACCESS_KEY_ID:
+    AWS_SECRET_ACCESS_KEY:
+    AWS_BIN_NAME: # Bucket name
+    AWS_REGION:
+    DEVISE_SECRET_KEY:                     blah-blah # use: `rails g secret` to generate a value

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,4 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
-# Mime::Type.register_alias "text/html", :iphone
+# Mime::Type.register_alias "text/html", :mobile


### PR DESCRIPTION
We added some logic to detect mobile browsers and remove the rich text editor in that case.  This successfully fixed the problem with making incomplete annotations on mobile browsers.
