### PR TITLE
CSV export and ideaspace backend

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -13,7 +13,14 @@ class AnnotationsController < ApplicationController
         if params[:document_id]
             loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
         end
+        @token = session['jwt']
         @loadOptions = loadOptions.to_json
+
+        respond_to do |format|
+            format.html { render :index }
+            format.json { render json: ApiRequester.search(loadOptions, @token) }
+            format.csv { send_data ApiRequester.search(loadOptions, @token, to_csv: true) }
+        end
     end
 
     def show

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,9 +1,22 @@
 class AnnotationsController < ApplicationController
-  before_filter :authenticate_user!
+    before_filter :authenticate_user!
 
-  def index
-  end
+    def index
+        loadOptions = {
+            :limit =>       100,
+            :groups =>      current_user.rep_group_list,
+            :subgroups =>   current_user.rep_subgroup_list,
+            :host =>        request.host_with_port,
+            :user =>        current_user.email,
+            :context =>     'dashboard'
+        }
+        if params[:document_id]
+            #loadOptions[:context] = 'document'
+            loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
+        end
+        @loadOptions = loadOptions.to_json
+    end
 
-  def show
-  end
+    def show
+    end
 end

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -8,10 +8,9 @@ class AnnotationsController < ApplicationController
             :subgroups =>   current_user.rep_subgroup_list,
             :host =>        request.host_with_port,
             :user =>        current_user.email,
-            :context =>     'dashboard'
+            :context =>     'search'
         }
         if params[:document_id]
-            #loadOptions[:context] = 'document'
             loadOptions[:uri] = request.base_url + '/documents/' + params[:document_id]
         end
         @loadOptions = loadOptions.to_json

--- a/app/views/annotations/index.html.erb
+++ b/app/views/annotations/index.html.erb
@@ -11,34 +11,16 @@
     var token = '<%= session["jwt"] %>';
     // Backbone.history.start({pushState: true, root: window.location})
 
-    var myLoadOptions = {
-      'limit': 100,
-      'groups': "<%= current_user.rep_group_list %>".split(/, /),
-      'subgroups': "<%= current_user.rep_subgroup_list %>".split(/, /),
-      'host': location.host,
-      'user': "<%= current_user.email %>",
-      'mode': 'user',
-      'context': 'dashboard',
-    };
-    var classLoadOptions = {
-      'limit': 100,
-      'groups': "<%= current_user.rep_group_list %>".split(/, /),
-      'subgroups': "<%= current_user.rep_subgroup_list %>".split(/, /),
-      'host': location.host,
-      'user': "<%= current_user.email %>",
-      'mode': 'class',
-      'context': 'dashboard',
-    };
-    var groupLoadOptions = {
-      'limit': 100,
-      'groups': "<%= current_user.rep_group_list %>".split(/, /),
-      'subgroups': "<%= current_user.rep_subgroup_list %>".split(/, /),
-      'host': location.host,
-      'user': "<%= current_user.email %>",
-      'mode': 'group',
-      'context': 'dashboard',
-    };
+    var loadOptions = JSON.parse('<%== @loadOptions %>');
 
+    var myLoadOptions = {'mode': 'user'};
+        classLoadOptions = {'mode': 'class'};
+        groupLoadOptions = {'mode': 'group'};
+    for (var attrname in loadOptions) {
+        myLoadOptions[attrname] = loadOptions[attrname];
+        classLoadOptions[attrname] = loadOptions[attrname];
+        groupLoadOptions[attrname] = loadOptions[attrname];
+    };
     widget.listAnnotations('my-annotation-list', myLoadOptions, endpoint, token);
     widget.listAnnotations('class-annotation-list', classLoadOptions, endpoint, token);
     widget.listAnnotations('group-annotation-list', groupLoadOptions, endpoint, token);

--- a/app/views/annotations/index.html.erb
+++ b/app/views/annotations/index.html.erb
@@ -8,7 +8,7 @@
   jQuery(function ($) {
     var widget = new Widget.App();
     var endpoint = '<%= ENV["API_URL"] %>';
-    var token = '<%= session["jwt"] %>';
+    var token = '<%= @token %>';
     // Backbone.history.start({pushState: true, root: window.location})
 
     var loadOptions = JSON.parse('<%== @loadOptions %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ AnnotationStudio::Application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
 
-  resources :documents
+  resources :documents do
+    resources :annotations
+  end
   resources :users, only: [:show, :edit]
 
 

--- a/lib/api_requester.rb
+++ b/lib/api_requester.rb
@@ -1,0 +1,36 @@
+require 'net/http'
+require 'multi_json'
+require 'csv'
+
+class ApiRequester
+	@@api_url = ENV['API_URL']
+
+	def self.search(params, token, to_csv: false)
+		url = URI.parse(@@api_url + '/search')
+		url.query = URI.encode_www_form(params)
+		request = Net::HTTP::Get.new(url)
+		# request['accept'] = 'application/json'
+		request['accept'] = 'text/csv'
+		request['x-annotator-auth-token'] = token
+		response = Net::HTTP.start(url.host, url.port) {|http| http.request(request)}
+		response.body
+		data = MultiJson.load(response.body)
+		to_csv == false ? data : CsvGenerator.to_csv(data)
+	end
+
+end
+
+class CsvGenerator
+	@@fields = ['id', 'user', 'username', 'text', 'uri', 'quote', 
+				'tags', 'ranges', 'subgroups', 'groups', 'updated', 'created']
+
+	def self.to_csv(data)
+		csv_string = CSV.generate do |csv|
+			csv << @@fields
+			data.each do |hash|
+				csv << hash.values_at(*@@fields)
+			end
+		end
+		csv_string
+	end
+end


### PR DESCRIPTION
This PR has two core features that extend the annotation controller:

- a `/documents/:document_id/annotations` endpoint, to view all annotations in a particular document
- `.csv` and `.json` format options (e.g. `/annotations.json` or  `/documents/:document_id/annotations.csv`)

This lets us do CSV export on a global or a per-document level. On the global level in the `/annotations` view it might look like:
`<%= link_to 'Export CSV', annotations_path(format: 'csv'), :class => 'btn btn-info' %>`

And in the document view (or document/annotations view) something like:
`<%= link_to 'Export CSV', document_annotations_path(@document, format: 'csv'), :class => 'btn btn-info' %>`